### PR TITLE
set register LAR for DWT to allow debug access

### DIFF
--- a/Src/profiling.c
+++ b/Src/profiling.c
@@ -67,6 +67,7 @@ void PROFILING_START(const char *profile_name)
   event_count = 0;
 
   CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+  DWT->LAR = 0xC5ACCE55;
   DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk; // enable counter
   //DWT->CYCCNT  = time_start = 0;
   time_start = DWT->CYCCNT;


### PR DESCRIPTION
Per https://stackoverflow.com/a/37345912. Allow access to debug regs. Tested on an STM32F767ZI.